### PR TITLE
fixed send near zero floating point number throught http

### DIFF
--- a/src/UbiProtocolHandler.cpp
+++ b/src/UbiProtocolHandler.cpp
@@ -143,7 +143,7 @@ void UbiProtocolHandler::buildHttpPayload(char *payload) {
   sprintf(payload, "{");
 
   for (uint8_t i = 0; i < _current_value;) {
-    char str_value[20];
+    char str_value[25];
     _floatToChar(str_value, (_dots + i)->dot_value);
     sprintf(payload, "%s\"%s\":{\"value\":%s", payload, (_dots + i)->variable_label, str_value);
 
@@ -264,11 +264,11 @@ void UbiProtocolHandler::setDebug(bool debug) {
  */
 
 void UbiProtocolHandler::_floatToChar(char *str_value, double value) {
-  char temp_arr[20];
+  char temp_arr[25];
   sprintf(temp_arr, "%.17g", value);
   uint8_t j = 0;
   uint8_t k = 0;
-  while (j < 20) {
+  while (j < 25) {
     if (temp_arr[j] != ' ') {
       str_value[k] = temp_arr[j];
       k++;


### PR DESCRIPTION
There was an error when the "buildHttpPayload" method invoked "_FloatToChar"
This was due to both methods having an incorrect buffer size for storing the
pretended data.

Explanation:
_FloatToChar method had a 20 bytes long buffer for storing a double data type number with 16
precision digits, consider the number 100.23/200000000 = 5.0115000000000006e-07 being used as input
for this function, then in the 20th position of this number represented as a string, there would be a
number "0"(the one preceeding the 7 on the exponential part)  instead of the termination character '\0'

Fix: increase buffer size from 20 to 25 in both of the method mentioned before, this fix consider
at least 2 digits long exponential part, i.e 5.0115000000000006e-99 and of course the termination
character.